### PR TITLE
Make Redis Server configurable via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Stop it with
 
     $ palava-machine-daemon stop
 
+### Configure using Environment Variables
+
+You can set the address of the redis server via environment variable. The default is 'localhost:6379'.
+
+    $ export PALAVA_REDIS="some_ip:some_port"
+    $ bin/palava-machine
+
 ### Specs
 
 To run the test suite use

--- a/lib/palava_machine/manager.rb
+++ b/lib/palava_machine/manager.rb
@@ -69,7 +69,7 @@ module PalavaMachine
 
 
     def initialize(options = {})
-      @redis_address = 'localhost:6379'
+      @redis_address = ENV['PALAVA_REDIS'] || 'localhost:6379'
       @redis_db      = options[:db] || 0
       @connections   = SocketStore.new
       @log           = Logger.new(STDOUT)


### PR DESCRIPTION
On environments where the redis server runs on a different machine/ip than localhost (e.g. Docker), palava-machine fails to start. It is unable to connect to the Redis server.

This PR adds the option to define the correct connection data via the environment varibale `PALAVA_REDIS`.

The new option is documented in `README.md`.
